### PR TITLE
Mapper lib

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,12 @@
 			<artifactId>AdminLTE</artifactId>
 			<version>${webjar-adminlte.version}</version>
 		</dependency>
+
+        <dependency>
+            <groupId>org.modelmapper</groupId>
+            <artifactId>modelmapper</artifactId>
+            <version>3.0.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/dev/otthon/sistemaweb/config/MapperProviders.java
+++ b/src/main/java/dev/otthon/sistemaweb/config/MapperProviders.java
@@ -1,0 +1,7 @@
+package dev.otthon.sistemaweb.config;
+
+public enum MapperProviders {
+
+    LOCAL,
+    MODELMAPPER;
+}

--- a/src/main/java/dev/otthon/sistemaweb/config/ModelMapperConfig.java
+++ b/src/main/java/dev/otthon/sistemaweb/config/ModelMapperConfig.java
@@ -1,12 +1,26 @@
 package dev.otthon.sistemaweb.config;
 
+import dev.otthon.sistemaweb.core.models.Address;
 import dev.otthon.sistemaweb.core.models.Client;
+import dev.otthon.sistemaweb.core.models.Employee;
+import dev.otthon.sistemaweb.core.models.Project;
 import dev.otthon.sistemaweb.core.utils.StringUtils;
 import dev.otthon.sistemaweb.web.clients.dtos.ClientForm;
+import dev.otthon.sistemaweb.web.employees.dtos.AddressForm;
+import dev.otthon.sistemaweb.web.employees.dtos.EmployeeDetails;
+import dev.otthon.sistemaweb.web.employees.dtos.EmployeeForm;
+import dev.otthon.sistemaweb.web.employees.dtos.EmployeeListItem;
+import dev.otthon.sistemaweb.web.projects.dtos.ProjectDetails;
+import dev.otthon.sistemaweb.web.projects.dtos.ProjectForm;
+import dev.otthon.sistemaweb.web.projects.dtos.ProjectListItem;
+import dev.otthon.sistemaweb.web.projects.dtos.ProjectTeamListItem;
 import org.modelmapper.Converter;
 import org.modelmapper.ModelMapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Configuration
 public class ModelMapperConfig {
@@ -28,6 +42,111 @@ public class ModelMapperConfig {
                         .map(Client::getPhone, ClientForm::setPhone)
                 );
 
+        modelMapper.createTypeMap(AddressForm.class, Address.class)
+                .addMappings(mapper -> mapper
+                        .using(toCleanedZipCode())
+                        .map(AddressForm::getZipCode, Address::setZipCode)
+                );
+
+        modelMapper.createTypeMap(Address.class, AddressForm.class)
+                .addMappings(mapper -> mapper
+                        .using(toFormattedZipCode())
+                        .map(Address::getZipCode, AddressForm::setZipCode)
+                );
+
+        modelMapper.createTypeMap(EmployeeForm.class, Employee.class)
+                .addMappings(mapper -> mapper
+                        .using(toCleanedCpf())
+                        .map(EmployeeForm::getCpf, Employee::setCpf)
+                )
+                .addMappings(mapper -> mapper
+                        .using(toCleanedPhone())
+                        .map(EmployeeForm::getPhone, Employee::setPhone)
+                );
+
+        modelMapper.createTypeMap(Employee.class, EmployeeForm.class)
+                .addMappings(mapper -> mapper
+                        .using(toFormattedCpf())
+                        .map(Employee::getCpf, EmployeeForm::setCpf)
+                )
+                .addMappings(mapper -> mapper
+                        .using(toFormattedPhone())
+                        .map(Employee::getPhone, EmployeeForm::setPhone)
+                );
+
+        modelMapper.createTypeMap(Employee.class, EmployeeListItem.class)
+                .addMappings(mapper -> mapper
+                        .map(src -> src.getPosition().getName(), EmployeeListItem::setPosition)
+                )
+                .addMappings(mapper -> mapper
+                        .using(toFormattedPhone())
+                        .map(Employee::getPhone, EmployeeListItem::setPhone)
+                );
+
+        modelMapper.createTypeMap(Employee.class, EmployeeDetails.class)
+                .addMappings(mapper -> mapper
+                        .using(toFormattedCpf())
+                        .map(Employee::getCpf, EmployeeDetails::setCpf)
+                )
+                .addMappings(mapper -> mapper
+                        .using(toFormattedPhone())
+                        .map(Employee::getPhone, EmployeeDetails::setPhone)
+                )
+                .addMappings(mapper -> mapper
+                        .map(src -> src.getPosition().getName(), EmployeeDetails::setPosition)
+                )
+                .addMappings(mapper -> mapper
+                        .using(toFormattedAddress())
+                        .map(Employee::getAddress, EmployeeDetails::setAddress)
+                );
+
+        modelMapper.createTypeMap(Project.class, ProjectListItem.class)
+                .addMappings(mapper -> mapper
+                        .map(src -> src.getClient().getName(), ProjectListItem::setClient)
+                )
+                .addMappings(mapper -> mapper
+                        .map(src -> src.getManager().getName(), ProjectListItem::setManager)
+                );
+
+        modelMapper.createTypeMap(ProjectForm.class, Project.class)
+                .addMappings(mapper -> mapper
+                        .using(toClient())
+                        .map(ProjectForm::getClient, Project::setClient)
+                )
+                .addMappings(mapper -> mapper
+                        .using(toEmployee())
+                        .map(ProjectForm::getManager, Project::setManager)
+                )
+                .addMappings(mapper -> mapper
+                        .using(toEmployees())
+                        .map(ProjectForm::getTeam, Project::setTeam)
+                );
+
+        modelMapper.createTypeMap(Project.class, ProjectForm.class)
+                .addMappings(mapper -> mapper
+                        .map(src -> src.getClient().getId(), ProjectForm::setClient)
+                )
+                .addMappings(mapper -> mapper
+                        .map(src -> src.getManager().getId(), ProjectForm::setManager)
+                )
+                .addMappings(mapper -> mapper
+                        .using(toEmployeeIds())
+                        .map(Project::getTeam, ProjectForm::setTeam)
+                );
+
+        modelMapper.createTypeMap(Project.class, ProjectDetails.class)
+                .addMappings(mapper -> mapper
+                        .map(src -> src.getClient().getName(), ProjectDetails::setClient)
+                )
+                .addMappings(mapper -> mapper
+                        .map(src -> src.getManager().getName(), ProjectDetails::setManager)
+                );
+
+        modelMapper.createTypeMap(Employee.class, ProjectTeamListItem.class)
+                .addMappings(mapper -> mapper
+                        .map(src -> src.getPosition().getName(), ProjectTeamListItem::setPosition)
+                );
+
         return modelMapper;
     }
 
@@ -38,4 +157,58 @@ public class ModelMapperConfig {
     private Converter<String, String> toFormattedPhone() {
         return context -> StringUtils.formatPhone(context.getSource());
     }
+
+    private Converter<String, String> toCleanedZipCode() {
+        return context -> StringUtils.cleanZipCode(context.getSource());
+    }
+
+    private Converter<String, String> toFormattedZipCode() {
+        return context -> StringUtils.formatZipCode(context.getSource());
+    }
+
+    private Converter<String, String> toCleanedCpf() {
+        return context -> StringUtils.cleanCpf(context.getSource());
+    }
+
+    private Converter<String, String> toFormattedCpf() {
+        return context -> StringUtils.formatCpf(context.getSource());
+    }
+
+    private Converter<Address, String> toFormattedAddress() {
+        return context -> String.format(
+                "%s, %s - %s - %s - %s",
+                context.getSource().getStreet(),
+                context.getSource().getNumber(),
+                context.getSource().getNeighborhood(),
+                context.getSource().getCity(),
+                context.getSource().getState()
+        );
+    }
+
+    private Converter<Long, Client> toClient() {
+        return context -> Client.builder()
+                .id(context.getSource())
+                .build();
+    }
+
+    private Converter<Long, Employee> toEmployee() {
+        return context -> Employee.builder()
+                .id(context.getSource())
+                .build();
+    }
+
+    private Converter<List<Long>, List<Employee>> toEmployees() {
+        return context -> context.getSource()
+                .stream()
+                .map((id) -> Employee.builder().id(id).build())
+                .collect(Collectors.toList());
+    }
+
+    private Converter<List<Employee>, List<Long>> toEmployeeIds() {
+        return context -> context.getSource()
+                .stream()
+                .map(Employee::getId)
+                .toList();
+    }
+
 }

--- a/src/main/java/dev/otthon/sistemaweb/config/ModelMapperConfig.java
+++ b/src/main/java/dev/otthon/sistemaweb/config/ModelMapperConfig.java
@@ -1,5 +1,9 @@
 package dev.otthon.sistemaweb.config;
 
+import dev.otthon.sistemaweb.core.models.Client;
+import dev.otthon.sistemaweb.core.utils.StringUtils;
+import dev.otthon.sistemaweb.web.clients.dtos.ClientForm;
+import org.modelmapper.Converter;
 import org.modelmapper.ModelMapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -9,7 +13,29 @@ public class ModelMapperConfig {
 
     @Bean
     ModelMapper modelMapper() {
-        return new ModelMapper();
+
+        var modelMapper = new ModelMapper();
+
+        modelMapper.createTypeMap(ClientForm.class, Client.class)
+                .addMappings(mapper -> mapper
+                        .using(toCleanedPhone())
+                        .map(ClientForm::getPhone, Client::setPhone)
+                );
+
+        modelMapper.createTypeMap(Client.class, ClientForm.class)
+                .addMappings(mapper -> mapper
+                        .using(toFormattedPhone())
+                        .map(Client::getPhone, ClientForm::setPhone)
+                );
+
+        return modelMapper;
     }
 
+    private Converter<String, String> toCleanedPhone() {
+        return context -> StringUtils.cleanPhone(context.getSource());
+    }
+
+    private Converter<String, String> toFormattedPhone() {
+        return context -> StringUtils.formatPhone(context.getSource());
+    }
 }

--- a/src/main/java/dev/otthon/sistemaweb/config/ModelMapperConfig.java
+++ b/src/main/java/dev/otthon/sistemaweb/config/ModelMapperConfig.java
@@ -1,0 +1,15 @@
+package dev.otthon.sistemaweb.config;
+
+import org.modelmapper.ModelMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ModelMapperConfig {
+
+    @Bean
+    ModelMapper modelMapper() {
+        return new ModelMapper();
+    }
+
+}

--- a/src/main/java/dev/otthon/sistemaweb/web/clients/mappers/ClientMapperImpl.java
+++ b/src/main/java/dev/otthon/sistemaweb/web/clients/mappers/ClientMapperImpl.java
@@ -4,9 +4,14 @@ import dev.otthon.sistemaweb.core.models.Client;
 import dev.otthon.sistemaweb.core.utils.StringUtils;
 import dev.otthon.sistemaweb.web.clients.dtos.ClientForm;
 import dev.otthon.sistemaweb.web.clients.dtos.ClientListItem;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 @Component
+@ConditionalOnProperty(
+        name = "dev.otthon.sistemaweb.mappers.provider",
+        havingValue = "local"
+)
 public class ClientMapperImpl implements ClientMapper {
 
     @Override

--- a/src/main/java/dev/otthon/sistemaweb/web/clients/mappers/ModelMapperClientMapper.java
+++ b/src/main/java/dev/otthon/sistemaweb/web/clients/mappers/ModelMapperClientMapper.java
@@ -1,0 +1,35 @@
+package dev.otthon.sistemaweb.web.clients.mappers;
+
+import dev.otthon.sistemaweb.core.models.Client;
+import dev.otthon.sistemaweb.web.clients.dtos.ClientForm;
+import dev.otthon.sistemaweb.web.clients.dtos.ClientListItem;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(
+        name = "dev.otthon.sistemaweb.mappers.provider",
+        havingValue = "modelmapper"
+)
+public class ModelMapperClientMapper implements ClientMapper {
+
+    private final ModelMapper modelMapper;
+
+    @Override
+    public Client toClient(ClientForm clientForm) {
+        return modelMapper.map(clientForm, Client.class);
+    }
+
+    @Override
+    public ClientForm toClientForm(Client client) {
+        return modelMapper.map(client, ClientForm.class);
+    }
+
+    @Override
+    public ClientListItem toClientListItem(Client client) {
+        return modelMapper.map(client, ClientListItem.class);
+    }
+}

--- a/src/main/java/dev/otthon/sistemaweb/web/employees/mappers/AddressMapperImpl.java
+++ b/src/main/java/dev/otthon/sistemaweb/web/employees/mappers/AddressMapperImpl.java
@@ -3,9 +3,14 @@ package dev.otthon.sistemaweb.web.employees.mappers;
 import dev.otthon.sistemaweb.core.models.Address;
 import dev.otthon.sistemaweb.core.utils.StringUtils;
 import dev.otthon.sistemaweb.web.employees.dtos.AddressForm;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 @Component
+@ConditionalOnProperty(
+        name = "dev.otthon.sistemaweb.mappers.provider",
+        havingValue = "local"
+)
 public class AddressMapperImpl implements AddressMapper{
 
     @Override

--- a/src/main/java/dev/otthon/sistemaweb/web/employees/mappers/EmployeeMapperImpl.java
+++ b/src/main/java/dev/otthon/sistemaweb/web/employees/mappers/EmployeeMapperImpl.java
@@ -9,10 +9,15 @@ import dev.otthon.sistemaweb.web.employees.dtos.EmployeeDetails;
 import dev.otthon.sistemaweb.web.employees.dtos.EmployeeForm;
 import dev.otthon.sistemaweb.web.employees.dtos.EmployeeListItem;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
+@ConditionalOnProperty(
+        name = "dev.otthon.sistemaweb.mappers.provider",
+        havingValue = "local"
+)
 public class EmployeeMapperImpl implements EmployeeMapper {
 
     private final AddressMapper addressMapper;

--- a/src/main/java/dev/otthon/sistemaweb/web/employees/mappers/EmployeeProjectMapperImpl.java
+++ b/src/main/java/dev/otthon/sistemaweb/web/employees/mappers/EmployeeProjectMapperImpl.java
@@ -2,9 +2,14 @@ package dev.otthon.sistemaweb.web.employees.mappers;
 
 import dev.otthon.sistemaweb.core.models.Project;
 import dev.otthon.sistemaweb.web.employees.dtos.EmployeeProjectListItem;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 @Component
+@ConditionalOnProperty(
+        name = "dev.otthon.sistemaweb.mappers.provider",
+        havingValue = "local"
+)
 public class EmployeeProjectMapperImpl implements EmployeeProjectMapper {
 
     @Override

--- a/src/main/java/dev/otthon/sistemaweb/web/employees/mappers/ModelMapperEmployeeMapper.java
+++ b/src/main/java/dev/otthon/sistemaweb/web/employees/mappers/ModelMapperEmployeeMapper.java
@@ -1,0 +1,41 @@
+package dev.otthon.sistemaweb.web.employees.mappers;
+
+import dev.otthon.sistemaweb.core.models.Employee;
+import dev.otthon.sistemaweb.web.employees.dtos.EmployeeDetails;
+import dev.otthon.sistemaweb.web.employees.dtos.EmployeeForm;
+import dev.otthon.sistemaweb.web.employees.dtos.EmployeeListItem;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(
+        name = "dev.otthon.sistemaweb.mappers.provider",
+        havingValue = "modelmapper"
+)
+public class ModelMapperEmployeeMapper implements EmployeeMapper {
+
+    private final ModelMapper modelMapper;
+
+    @Override
+    public Employee toEmployee(EmployeeForm employeeForm) {
+        return modelMapper.map(employeeForm, Employee.class);
+    }
+
+    @Override
+    public EmployeeForm toEmployeeForm(Employee employee) {
+        return modelMapper.map(employee, EmployeeForm.class);
+    }
+
+    @Override
+    public EmployeeListItem toEmployeeListItem(Employee employee) {
+        return modelMapper.map(employee, EmployeeListItem.class);
+    }
+
+    @Override
+    public EmployeeDetails toEmployeeDetails(Employee employee) {
+        return modelMapper.map(employee, EmployeeDetails.class);
+    }
+}

--- a/src/main/java/dev/otthon/sistemaweb/web/positions/mappers/ModelMapperPositionMapper.java
+++ b/src/main/java/dev/otthon/sistemaweb/web/positions/mappers/ModelMapperPositionMapper.java
@@ -3,35 +3,36 @@ package dev.otthon.sistemaweb.web.positions.mappers;
 import dev.otthon.sistemaweb.core.models.Position;
 import dev.otthon.sistemaweb.web.positions.dtos.PositionForm;
 import dev.otthon.sistemaweb.web.positions.dtos.PositionListItem;
+import org.modelmapper.ModelMapper;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 @Component
 @ConditionalOnProperty(
         name = "dev.otthon.sistemaweb.mappers.provider",
-        havingValue = "local"
+        havingValue = "modelmapper"
 )
-public class PositionMapperImpl implements PositionMapper {
+public class ModelMapperPositionMapper implements PositionMapper{
+
+    private final ModelMapper modelMapper;
+
+    public ModelMapperPositionMapper(ModelMapper modelMapper) {
+        this.modelMapper = modelMapper;
+    }
+
     @Override
     public PositionForm toPositionForm(Position position) {
-        return PositionForm.builder()
-                .name(position.getName())
-                .build();
+        return modelMapper.map(position, PositionForm.class);
     }
 
     @Override
     public Position toPosition(PositionForm positionForm) {
-        System.out.println("Utilizando o mapper local");
-        return Position.builder()
-                .name(positionForm.getName())
-                .build();
+        System.out.println("Utilizando a lib modelmapper");
+        return modelMapper.map(positionForm, Position.class);
     }
 
     @Override
     public PositionListItem toPositionListItem(Position position) {
-        return PositionListItem.builder()
-                .id(position.getId())
-                .name(position.getName())
-                .build();
+        return modelMapper.map(position, PositionListItem.class);
     }
 }

--- a/src/main/java/dev/otthon/sistemaweb/web/positions/mappers/ModelMapperPositionMapper.java
+++ b/src/main/java/dev/otthon/sistemaweb/web/positions/mappers/ModelMapperPositionMapper.java
@@ -3,11 +3,13 @@ package dev.otthon.sistemaweb.web.positions.mappers;
 import dev.otthon.sistemaweb.core.models.Position;
 import dev.otthon.sistemaweb.web.positions.dtos.PositionForm;
 import dev.otthon.sistemaweb.web.positions.dtos.PositionListItem;
+import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 @ConditionalOnProperty(
         name = "dev.otthon.sistemaweb.mappers.provider",
         havingValue = "modelmapper"
@@ -16,9 +18,10 @@ public class ModelMapperPositionMapper implements PositionMapper{
 
     private final ModelMapper modelMapper;
 
-    public ModelMapperPositionMapper(ModelMapper modelMapper) {
-        this.modelMapper = modelMapper;
-    }
+//     Construtor foi substituito pela annotation @RequiredArgsConstrutor
+//    public ModelMapperPositionMapper(ModelMapper modelMapper) {
+//        this.modelMapper = modelMapper;
+//    }
 
     @Override
     public PositionForm toPositionForm(Position position) {

--- a/src/main/java/dev/otthon/sistemaweb/web/projects/mappers/ModelMapperProjectMapper.java
+++ b/src/main/java/dev/otthon/sistemaweb/web/projects/mappers/ModelMapperProjectMapper.java
@@ -1,0 +1,41 @@
+package dev.otthon.sistemaweb.web.projects.mappers;
+
+import dev.otthon.sistemaweb.core.models.Project;
+import dev.otthon.sistemaweb.web.projects.dtos.ProjectDetails;
+import dev.otthon.sistemaweb.web.projects.dtos.ProjectForm;
+import dev.otthon.sistemaweb.web.projects.dtos.ProjectListItem;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(
+        name = "dev.otthon.sistemaweb.mappers.provider",
+        havingValue = "modelmapper"
+)
+public class ModelMapperProjectMapper implements ProjectMapper {
+
+    private final ModelMapper modelMapper;
+
+    @Override
+    public ProjectListItem toProjectListItem(Project project) {
+        return modelMapper.map(project, ProjectListItem.class);
+    }
+
+    @Override
+    public ProjectDetails toProjectDetails(Project project) {
+        return modelMapper.map(project, ProjectDetails.class);
+    }
+
+    @Override
+    public Project toProject(ProjectForm projectForm) {
+        return modelMapper.map(projectForm, Project.class);
+    }
+
+    @Override
+    public ProjectForm toProjectForm(Project project) {
+        return modelMapper.map(project, ProjectForm.class);
+    }
+}

--- a/src/main/java/dev/otthon/sistemaweb/web/projects/mappers/ProjectMapperImpl.java
+++ b/src/main/java/dev/otthon/sistemaweb/web/projects/mappers/ProjectMapperImpl.java
@@ -10,10 +10,15 @@ import dev.otthon.sistemaweb.web.projects.dtos.ProjectDetails;
 import dev.otthon.sistemaweb.web.projects.dtos.ProjectForm;
 import dev.otthon.sistemaweb.web.projects.dtos.ProjectListItem;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
+@ConditionalOnProperty(
+        name = "dev.otthon.sistemaweb.mappers.provider",
+        havingValue = "local"
+)
 public class ProjectMapperImpl implements ProjectMapper {
 
     private final ClientRepository clientRepository;

--- a/src/main/java/dev/otthon/sistemaweb/web/projects/mappers/ProjectTeamMapperImpl.java
+++ b/src/main/java/dev/otthon/sistemaweb/web/projects/mappers/ProjectTeamMapperImpl.java
@@ -2,9 +2,14 @@ package dev.otthon.sistemaweb.web.projects.mappers;
 
 import dev.otthon.sistemaweb.core.models.Employee;
 import dev.otthon.sistemaweb.web.projects.dtos.ProjectTeamListItem;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 @Component
+@ConditionalOnProperty(
+        name = "dev.otthon.sistemaweb.mappers.provider",
+        havingValue = "local"
+)
 public class ProjectTeamMapperImpl implements ProjectTeamMapper {
 
     @Override

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,9 @@
+{
+  "properties": [
+    {
+      "name": "dev.otthon.sistemaweb.mappers.provider",
+      "type": "dev.otthon.sistemaweb.config.MapperProviders",
+      "description": "Implementação a ser utilizada para a camada mapper"
+    }
+  ]
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,3 +16,4 @@ spring.h2.console.path=/h2-console
 
 # Propriedade Própria
 dev.otthon.sistemaweb.mappers.provider=modelmapper
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,3 +13,6 @@ spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 # Hibernate Configuration
 spring.h2.console.enabled=true
 spring.h2.console.path=/h2-console
+
+# Propriedade Própria
+dev.otthon.sistemaweb.mappers.provider=modelmapper


### PR DESCRIPTION
O ModelMapper é uma biblioteca Java que ajuda a converter objetos de um tipo para outro de maneira fácil. 

Ele é muito útil em aplicações Spring para transformar dados entre diferentes camadas da aplicação, como converter entidades de banco de dados para objetos de transferência de dados (DTOs) e vice-versa.

### Principais Vantagens do ModelMapper

- **Automatização do Mapeamento**: Ele faz a conversão automaticamente, seguindo convenções, o que significa menos código para escrever.
- **Flexibilidade e Personalização**: Você pode definir regras específicas de conversão quando necessário.
- **Simplicidade**: Simplifica o código, eliminando a necessidade de escrever manualmente a lógica de conversão.

### Por que usar ModelMapper no Spring?

1. **Menos Código Repetitivo**: Elimina a necessidade de escrever código repetitivo para converter entre diferentes tipos de objetos.
2. **Facilidade de Manutenção**: Facilita a manutenção do código, pois qualquer alteração na estrutura dos objetos pode ser gerenciada no mapeamento.
3. **Código Mais Limpo**: Mantém a lógica de conversão separada da lógica de negócios, resultando em um código mais organizado.